### PR TITLE
Fix for npm run pack-zip. 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
     Response,
     StdAccountCreateInput,
     StdAccountCreateOutput,
+    StdAccountListInput,
     StdAccountListOutput,
     StdAccountReadInput,
     StdAccountReadOutput,
@@ -65,7 +66,7 @@ export const connector = async () => {
                 res.send({})
             }
         })
-        .stdAccountList(async (context: Context, input: undefined, res: Response<StdAccountListOutput>) => {
+        .stdAccountList(async (context: Context, input: StdAccountListInput, res: Response<StdAccountListOutput>) => {
             if (config.enableOrphanIdentities) {
                 const response: AxiosResponse = await client.collectOrphanAccounts()
                 for (const acc of response.data) {


### PR DESCRIPTION
It was giving an error TS2345: Argument of type '(context: Context, input: undefined, res: Response<StdAccountListOutput>) => Promise<void>' is not assignable to parameter of type 'StdAccountListHandler'.
  Types of parameters 'input' and 'input' are incompatible.
    Type 'StdAccountListInput' is not assignable to type 'undefined'.

The fix was to set input to StdAccountListInput. I think this is due to an SDK change referenced here: https://developer.sailpoint.com/discuss/t/connectorerror-with-new-connector-that-uses-saas-connectivity-framework/15220